### PR TITLE
Fixes link for plugin docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ yo fly
 
 The project template includes:
 
-+ `index.js` Template for a transformer plugin. To create more advanced plugins such as `linters`, `testers` and async transformers see the [documentation](https://github.com/flyjs/fly/docs/README.md#plugins).
++ `index.js` Template for a transformer plugin. To create more advanced plugins such as `linters`, `testers` and async transformers see the [documentation](https://github.com/flyjs/fly/blob/master/docs/README.md).
 
 + `README.md` Customized template.
 


### PR DESCRIPTION
Fixes link url in README for https://github.com/flyjs/generator-fly/issues/6. Here is my patch preview: https://github.com/watilde/generator-fly/tree/patch/fixes-link#features